### PR TITLE
Add nRF52840 DK build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ You can then build the firmware by running the following commands.
 west build -b healthypi_move_nrf5340_cpuapp application/app
 west flash
 ```
+To build for the nRF52840 development kit, specify the board when invoking `west` or the provided build scripts:
+
+```
+west build -b nrf52840dk_nrf52840 application/app
+```
 
 You can also open the project in Visual Studio Code and use the nRF Connect extension to open the project and build the firmware from there. This will ensure that you have all the required tools installed. For more about installing the nRF Connect extension, please refer to [Nordic's Documentation](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation/install_ncs.html).
 

--- a/app/CMakePresets.json
+++ b/app/CMakePresets.json
@@ -13,6 +13,15 @@
             "cacheVariables": {
                 "BOARD": "healthypi_move/nrf5340/cpuapp"
             }
+        },
+        {
+            "name": "build-nrf52840",
+            "displayName": "Build for nRF52840 DK",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build-nrf52840",
+            "cacheVariables": {
+                "BOARD": "nrf52840dk_nrf52840"
+            }
         }
     ]
 }

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,9 @@
-west build --build-dir app/build app --board healthypi_move/nrf5340/cpuapp -- -DBOARD_ROOT=.
+#!/bin/sh
+
+# Simple wrapper to build the application for a given board.
+# Usage: ./build.sh [board-name]
+# If no board is provided, default to Healthypi Move custom board.
+
+BOARD=${1:-healthypi_move/nrf5340/cpuapp}
+
+west build --build-dir app/build app --board $BOARD -- -DBOARD_ROOT=.

--- a/pristine.sh
+++ b/pristine.sh
@@ -1,1 +1,9 @@
-west build --build-dir app/build app --pristine --board healthypi_move/nrf5340/cpuapp -- -DBOARD_ROOT=.
+#!/bin/sh
+
+# Build the application with a pristine build directory for a given board.
+# Usage: ./pristine.sh [board-name]
+# If no board is provided, default to Healthypi Move custom board.
+
+BOARD=${1:-healthypi_move/nrf5340/cpuapp}
+
+west build --build-dir app/build app --pristine --board $BOARD -- -DBOARD_ROOT=.


### PR DESCRIPTION
## Summary
- allow choosing target board in build scripts
- add CMake preset for nRF52840 development kit
- document how to build for the nRF52840 DK

## Testing
- `./build.sh nrf52840dk_nrf52840` *(fails: west: not found)*
- `./pristine.sh nrf52840dk_nrf52840` *(fails: west: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0711ad680832aa2f604f38b053205